### PR TITLE
fix hardcoded title in visualize_dihedrals

### DIFF
--- a/.src/visualization_fuctions.py
+++ b/.src/visualization_fuctions.py
@@ -16,7 +16,7 @@ def visualize_timeseries(time:Iterable, data:Iterable, title:str, y_label:str, x
   return figure
 
 def visualize_dihedrals(data:pd.DataFrame, 
-                        y_labels:str, x_labels:str, title:str,
+                        y_labels:str, x_labels:str, title:str="DIHEDRALS",
                         ncols=4, nrows=3, figsize=[20,20]):
   
   #multiplot:
@@ -34,7 +34,7 @@ def visualize_dihedrals(data:pd.DataFrame,
           ax.set_ylabel(y_labels)
       if(ind >= (nrows-1)*ncols):
           ax.set_xlabel(x_labels)
-  fig.suptitle("DIHEDRALS", y=0.95)
+  fig.suptitle(title, y=0.95)
   return fig
 
 


### PR DESCRIPTION
The students are asked to (optionally) add a title for the dihedrals plot:
```
data = dihedral_data
x_labels = "" #Add label/[units] for the x-axis
y_labels = "" #Add the label/[units] for the y-axis
title   = "" #Optional - Add a title for the plot, which describes in few words the content of the plot

vis.visualize_dihedrals(data=data, y_labels=y_labels, x_labels=x_labels, title=title)
pass
```
However, "DIHEDRALS" was hardcoded in the function visualize_dihedrals, meaning any title passed by the students would not be displayed in the actual figure.